### PR TITLE
SDK 3.0 - Set the playsinline property for video elements

### DIFF
--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -186,6 +186,7 @@ const addVideoNode = (participant, stream) => {
     videoContainer.appendChild(videoNode);
 
     videoNode.autoplay = 'autoplay';
+    videoNode.playsinline = true;
     videoNode.muted = true;
   }
 


### PR DESCRIPTION
Set the playsinline property for video elements to prevent Safari on iPhone to display a black screen instead of the video streams