### PR TITLE
SDK 2.4 - Set the playsinline property for video elements

### DIFF
--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -180,6 +180,7 @@ const addVideoNode = (participant, stream) => {
     videoContainer.appendChild(videoNode);
 
     videoNode.autoplay = 'autoplay';
+    videoNode.playsinline = true;
     videoNode.muted = true;
   }
 


### PR DESCRIPTION
Set the playsinline property for video elements to prevent Safari on iPhone to display a black screen instead of the video streams