### PR TITLE
Add Logging In Indicator

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,11 +9,8 @@
 
 <body>
     <div id="app">
-        <h1 id="name-message">You are logged out.</h1>
-        <div id="loader" style="display: none">
-            <p>Logging in...</p>
-        </div>
-        
+        <h1 id="name-message">Logging in...</h1>
+
         <!-- Join or Leave a Conference -->
         <div id="form">
             <label>Conference alias :</label>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,10 @@
 <body>
     <div id="app">
         <h1 id="name-message">You are logged out.</h1>
-
+        <div id="loader" style="display: none">
+            <p>Logging in...</p>
+        </div>
+        
         <!-- Join or Leave a Conference -->
         <div id="form">
             <label>Conference alias :</label>

--- a/src/scripts/client.js
+++ b/src/scripts/client.js
@@ -45,18 +45,11 @@ const main = async () => {
     // WARNING: It is best practice to use the VoxeetSDK.initializeToken function to initialize the SDK.
     // Please read the documentation at:
     // https://docs.dolby.io/interactivity/docs/initializing
-    
     VoxeetSDK.initialize('customerKey', 'customerSecret');
-    
-    // Show logging in indicator before user logged in
-    loader.style.display = 'block'
 
     // Open a session for the user
     await VoxeetSDK.session.open({ name: randomName });
-    
-    // Remove logging in indicator after user is logged in
-    loader.style.display = 'none'
-    
+
     // Initialize the UI
     initUI();
   } catch (e) {

--- a/src/scripts/client.js
+++ b/src/scripts/client.js
@@ -45,11 +45,18 @@ const main = async () => {
     // WARNING: It is best practice to use the VoxeetSDK.initializeToken function to initialize the SDK.
     // Please read the documentation at:
     // https://docs.dolby.io/interactivity/docs/initializing
+    
     VoxeetSDK.initialize('customerKey', 'customerSecret');
+    
+    // Show logging in indicator before user logged in
+    loader.style.display = 'block'
 
     // Open a session for the user
     await VoxeetSDK.session.open({ name: randomName });
-
+    
+    // Remove logging in indicator after user is logged in
+    loader.style.display = 'none'
+    
     // Initialize the UI
     initUI();
   } catch (e) {

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -204,7 +204,7 @@ const removeVideoNode = (participant) => {
 
 // Add a new participant to the list
 const addParticipantNode = (participant) => {
-  // If the participant is the current session user, don't add himself to the list
+  // If the participant is the current session user, don't add them to the list
   if (participant.id === VoxeetSDK.session.participant.id) return;
 
   let participantNode = document.createElement('li');


### PR DESCRIPTION
While following the documentation, it wasn't initially obvious why the join button wasn't clickable on page refresh until after some time. I think adding a logging in indicator would make this more obvious to readers.