### PR TITLE
Use full path to web sdk js to find wasm dependencies

### DIFF
--- a/video-calls/final/index.html
+++ b/video-calls/final/index.html
@@ -12,7 +12,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 
         <!-- Dolby.io Web SDK -->
-        <script type="text/javascript" src="https://unpkg.com/@voxeet/voxeet-web-sdk/dist/voxeet-sdk.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@voxeet/voxeet-web-sdk/dist/voxeet-sdk.js"></script>
         <script type="text/javascript" src="https://developer.dolby.io/demos/comms-sdk-web-getting-started/util/dolbyio-auth-helper.js"></script>
     </head>
 <body>

--- a/video-calls/final/index.html
+++ b/video-calls/final/index.html
@@ -12,8 +12,8 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 
         <!-- Dolby.io Web SDK -->
-        <script type="text/javascript" src="https://unpkg.com/@voxeet/voxeet-web-sdk"></script>
-        <script type="text/javascript" src="../util/dolbyio-auth-helper.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/@voxeet/voxeet-web-sdk/dist/voxeet-sdk.js"></script>
+        <script type="text/javascript" src="https://developer.dolby.io/demos/comms-sdk-web-getting-started/util/dolbyio-auth-helper.js"></script>
     </head>
 <body>
 


### PR DESCRIPTION
Use full path to SDK and helper library to insure modules are properly loaded from a CDN.